### PR TITLE
Remove unsafe flag -strict-concurrency=complete

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,9 +28,6 @@ let package = Package(
       name: "VergeTaskManager",
       dependencies: [
 //        .product(name: "Atomics", package: "swift-atomics")
-      ],
-      swiftSettings: [
-        SwiftSetting.unsafeFlags(["-strict-concurrency=complete"])
       ]
     ),
     .target(name: "VergeTiny", dependencies: []),


### PR DESCRIPTION
I updated from v9 to v10.1.0 and now my app project cannot be built due to the following error.

> The package product 'Verge' cannot be used as a dependency of this target because it uses unsafe build flags.

I believe that apps that depend on libraries containing targets that use unsafeFlags will not be able to build.

> As some build flags can be exploited for unsupported or malicious behavior, the use of unsafe flags makes the products containing this target ineligible for use by other packages.
https://developer.apple.com/documentation/packagedescription/swiftsetting/unsafeflags(_:_:)

Using a branch with this flag removed did not cause any errors in my project 😄 
