### PR TITLE
Fix argument dropsFirst not being used

### DIFF
--- a/Sources/Verge/Store/Store.swift
+++ b/Sources/Verge/Store/Store.swift
@@ -544,7 +544,7 @@ Mutation: (%@)
     queue: MainActorTargetQueue,
     receive: @escaping @MainActor (Changes<State>) -> Void
   ) -> StoreSubscription {
-    return _primitive_sinkState(queue: Queues.MainActor(queue), receive: receive)
+    return _primitive_sinkState(dropsFirst: dropsFirst, queue: Queues.MainActor(queue), receive: receive)
   }
   
   func _primitive_sinkState(


### PR DESCRIPTION
I was using `.sinkState(dropsFirst: true)` but `dropsFirst` wasn't working, and I found out this.